### PR TITLE
browser: make detectBrowsers() return hidden browsers by default

### DIFF
--- a/src/browser.go
+++ b/src/browser.go
@@ -35,11 +35,6 @@ func detectBrowsers() []*Browser {
 			continue
 		}
 
-		// Skip apps that shouldn't be shown
-		if !appInfo.ShouldShow() {
-			continue
-		}
-
 		name := appInfo.Name()
 		icon := ""
 		if gicon := appInfo.Icon(); gicon != nil {


### PR DESCRIPTION
We have a function to hide specific browsers now, so we don't need to infer from the desktop file's `NoDisplay` key. Also, this allows users to create hidden desktop files (for browser profiles, etc).