### PR TITLE
feat: add stay_alive option for running in the background

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	CheckDefaultBrowser bool          `toml:"check_default_browser"`
 	ShowAppNames        bool          `toml:"show_app_names"`
 	ForceDarkMode       bool          `toml:"force_dark_mode"`
+	StayAlive           bool          `toml:"stay_alive"`
 	Redirections        []Redirection `toml:"redirections,omitempty"`
 	Rules               []Rule        `toml:"rules"`
 }

--- a/src/main.go
+++ b/src/main.go
@@ -26,6 +26,9 @@ func main() {
 
 	app.ConnectActivate(func() {
 		cfg := loadConfig()
+		if cfg.StayAlive {
+			app.Hold()
+		}
 		setupApp(cfg)
 		browsers := detectBrowsers()
 		showSettingsWindow(app, browsers, cfg)
@@ -33,6 +36,9 @@ func main() {
 
 	app.ConnectOpen(func(files []gio.Filer, hint string) {
 		cfg := loadConfig()
+		if cfg.StayAlive {
+			app.Hold()
+		}
 		setupApp(cfg)
 		browsers := detectBrowsers()
 
@@ -120,7 +126,6 @@ func handleSwitchyardURL(app *adw.Application, browsers []*Browser, cfg *Config,
 			}
 			if browser := findBrowserByID(browsers, id); browser != nil {
 				launchBrowser(browser, sanitized)
-				app.Quit()
 				return
 			}
 		}
@@ -147,7 +152,6 @@ func handleURL(app *adw.Application, browsers []*Browser, cfg *Config, urlStr st
 		// Find the browser and launch it
 		if browser := findBrowserByID(browsers, browserID); browser != nil {
 			launchBrowser(browser, urlStr)
-			app.Quit()
 			return
 		}
 	}
@@ -156,7 +160,6 @@ func handleURL(app *adw.Application, browsers []*Browser, cfg *Config, urlStr st
 	if !cfg.PromptOnClick && cfg.FavoriteBrowser != "" {
 		if browser := findBrowserByID(browsers, cfg.FavoriteBrowser); browser != nil {
 			launchBrowser(browser, urlStr)
-			app.Quit()
 			return
 		}
 	}

--- a/src/settings_behavior.go
+++ b/src/settings_behavior.go
@@ -50,6 +50,13 @@ func createBehaviorPage(win *adw.Window, browsers []*Browser, cfg *Config) gtk.W
 	defaultRow.SetSelected(selectedIndex)
 
 	behaviorGroup.Add(defaultRow)
+
+	stayAliveRow := adw.NewSwitchRow()
+	stayAliveRow.SetTitle("Keep running in background")
+	stayAliveRow.SetSubtitle("Faster startup when opening links")
+	stayAliveRow.SetActive(cfg.StayAlive)
+	behaviorGroup.Add(stayAliveRow)
+
 	content.Append(behaviorGroup)
 
 	// Connect change handlers
@@ -70,6 +77,11 @@ func createBehaviorPage(win *adw.Window, browsers []*Browser, cfg *Config) gtk.W
 		} else if idx > 0 && int(idx) <= len(browsers) {
 			cfg.FavoriteBrowser = browsers[idx-1].ID
 		}
+		saveConfigWithFlag(cfg)
+	})
+
+	stayAliveRow.Connect("notify::active", func() {
+		cfg.StayAlive = stayAliveRow.Active()
 		saveConfigWithFlag(cfg)
 	})
 

--- a/src/window_settings.go
+++ b/src/window_settings.go
@@ -206,6 +206,7 @@ func watchConfigFile(cfg *Config, onChange func()) {
 					cfg.CheckDefaultBrowser = newCfg.CheckDefaultBrowser
 					cfg.ShowAppNames = newCfg.ShowAppNames
 					cfg.ForceDarkMode = newCfg.ForceDarkMode
+					cfg.StayAlive = newCfg.StayAlive
 					cfg.HiddenBrowsers = newCfg.HiddenBrowsers
 					cfg.Redirections = newCfg.Redirections
 					cfg.Rules = newCfg.Rules


### PR DESCRIPTION
Adds stay_alive option, which should improve startup performance for the launcher. Works by lingering in the background after initial launch--so we don't have to reinitialize the process (go runtime etc)