### PR TITLE
Add note about Flatpak + NixOS to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,17 @@ just flatpak # Build and install
 - [Configuration](docs/Configuration.md) - Config file format, rules, and settings.
 - [URI Scheme](docs/URI%20Scheme.md) - Custom `switchyard://` URLs for specifying browser preferences.
 - [Prior Art](docs/Prior%20Art.md) - Similar tools that inspired Switchyard.
+
+## Notes
+
+### Flaktpak on NixOS: host browsers are not detected
+
+On NixOS, browser desktop files live in `/run/current-system/sw/share/applications`, which is not visible inside Flatpak by default.
+
+To expose them to Switchyard, add the path to the XDG application search path:
+
+```bash
+flatpak override --user io.github.alyraffauf.Switchyard \
+  --filesystem=/run/current-system/sw/share:ro \
+  --env=XDG_DATA_DIRS=/app/share:/usr/share:/run/current-system/sw/share
+```


### PR DESCRIPTION
Adds note on how to expose host browsers on NixOS for the flatpak install.

It is a niche target audience, I feel a bit bad about polluting the README with this. But since flatpak is listed as a 'recommended' install option, other NixOS users might fall for the same trap as I did. Maybe once it is in nixpkgs, we could drop the 'recommended' note in the README and then NixOS peopel will just install it from nixpkgs and have no issues. :)